### PR TITLE
Add fallback in case user put white space to the checked value.

### DIFF
--- a/src/jquery.class_list.js
+++ b/src/jquery.class_list.js
@@ -27,6 +27,7 @@
         return;
     }
 
+    var originalHasClass = jQuery.fn.hasClass;
     var getClass = function getClass(elem) {
         return elem.getAttribute && elem.getAttribute('class') || '';
     };
@@ -150,6 +151,10 @@
         },
 
         hasClass: function (value) {
+            if (rnotwhite.test(value)) {
+              return originalHasClass(value);
+            }
+
             var i = 0;
             var l = this.length;
 


### PR DESCRIPTION
In the latest version of jQuery usage of white space if "hasClass" function is valid. In case we will use "classList" plugin, it will throw an error.

#### Example:
```javascript
$('body').hasClass('class-1 class-2'); // valid
document.body.classList.contains('class-1 class-2') // will throw
```

Solution is to fallback to original function of jQuery in case value contains white space.